### PR TITLE
Writing a unit test to simulate partial read bytes scenarios in readPageHeader

### DIFF
--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -209,6 +209,12 @@
       <version>${commons-lang3.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>0.21.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -215,8 +215,15 @@
       <version>0.21.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud.bigdataoss</groupId>
+      <artifactId>gcs-connector</artifactId>
+      <!-- Use a version compatible with your Hadoop dependencies -->
+      <version>3.0.5</version>
+      <classifier>shaded</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestPageHeaderPartialRead.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestPageHeaderPartialRead.java
@@ -5,10 +5,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
+import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.column.ParquetProperties;
@@ -44,7 +42,7 @@ public class TestPageHeaderPartialRead {
 
   // Path to the pre-existing Parquet file.
   // This file should be placed in the /dev/shm directory to insure in-memory reads.
-  private static final String PARQUET_FILE_PATH = "/dev/shm/test.parquet";
+  private static final String PARQUET_FILE_PATH = "gs://anim_test-bucket-1/titanic.parquet";
 
   // Offset at which fault will occur.
   private static final int FAULT_OFFSET = 10;
@@ -59,8 +57,7 @@ public class TestPageHeaderPartialRead {
   @Before
   public void setup() throws IOException {
     if (READ_FROM_DISK) {
-      File file = new File(PARQUET_FILE_PATH);
-      filePath = new Path(file.toURI());
+      filePath = new Path(URI.create(PARQUET_FILE_PATH));
     } else {
       // 1. Define a simple schema
       MessageType schema = Types.buildMessage()
@@ -113,6 +110,13 @@ public class TestPageHeaderPartialRead {
   }
 
   private static InputFile getInputFile() throws IOException {
+    if (PARQUET_FILE_PATH.startsWith("gs://")) {
+      // Set properties to enable gRPC
+      conf.setBoolean("fs.gs.grpc.enable", true);
+      conf.set("fs.gs.client.type", "STORAGE_CLIENT");
+      conf.set("fs.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem");
+      conf.set("fs.AbstractFileSystem.gs.impl", "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS");
+    }
     if (READ_FROM_DISK) {
       return HadoopInputFile.fromPath(filePath, conf);
     } else {
@@ -123,7 +127,7 @@ public class TestPageHeaderPartialRead {
   // Full read of PageHeader from a valid stream should succeed.
   @Test
   public void fullReadOfPageHeaderShouldSucceed() {
-    try(SeekableInputStream stream = getInputFile().newStream()) {
+    try (SeekableInputStream stream = getInputFile().newStream()) {
       stream.seek(pageHeaderOffset);
       Util.readPageHeader(stream);
     } catch (Exception e) {
@@ -156,7 +160,8 @@ public class TestPageHeaderPartialRead {
 
     // Create a seekable stream and wrap it with our fault-injecting stream
     try (SeekableInputStream underlyingStream = getInputFile().newStream()) {
-      PartialReadInputStream faultyStream = new PartialReadInputStream(underlyingStream, absoluteFaultPosition, true);
+      PartialReadInputStream faultyStream =
+          new PartialReadInputStream(underlyingStream, absoluteFaultPosition, true);
 
       // Assert that attempting to read the header from this faulty stream throws the expected exception
       assertThrows("A partial read within the PageHeader should cause an IOException.", IOException.class, () -> {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestPageHeaderPartialRead.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestPageHeaderPartialRead.java
@@ -1,0 +1,259 @@
+package org.apache.parquet.hadoop;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.format.PageHeader;
+import org.apache.parquet.format.Util;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.example.GroupWriteSupport;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
+import org.apache.parquet.hadoop.util.PartialReadInputStream;
+import org.apache.parquet.io.DelegatingSeekableInputStream;
+import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+import org.apache.parquet.io.SeekableInputStream;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestPageHeaderPartialRead {
+
+  // Flag to control read source.
+  // true: read from a pre-existing file on disk.
+  // false: create a file in memory and read from it.
+  private static final boolean READ_FROM_DISK = true;
+
+  // Path to the pre-existing Parquet file.
+  // This file should be placed in the /dev/shm directory to insure in-memory reads.
+  private static final String PARQUET_FILE_PATH = "/dev/shm/test.parquet";
+
+  // Offset at which fault will occur.
+  private static final int FAULT_OFFSET = 10;
+
+  private static Configuration conf = new Configuration();
+  private static Path filePath;
+
+  private static byte[] parquetFileBytes;
+  private static long pageHeaderOffset;
+  private static int pageHeaderLength;
+
+  @Before
+  public void setup() throws IOException {
+    if (READ_FROM_DISK) {
+      File file = new File(PARQUET_FILE_PATH);
+      filePath = new Path(file.toURI());
+    } else {
+      // 1. Define a simple schema
+      MessageType schema = Types.buildMessage()
+          .required(PrimitiveTypeName.BINARY)
+          .as(org.apache.parquet.schema.LogicalTypeAnnotation.stringType())
+          .named("name")
+          .named("test_schema");
+
+      Configuration conf = new Configuration();
+      GroupWriteSupport.setSchema(schema, conf);
+      SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+      // 2. Write a simple Parquet file to an in-memory byte array
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+      GroupWriteSupport.setSchema(schema, conf);
+      OutputFile newFile = new MemoryOutputFile(baos);
+
+      try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(newFile)
+          .withConf(conf)
+          .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+          .withRowGroupSize(1024)
+          .withPageSize(1024)
+          .withWriterVersion(ParquetProperties.WriterVersion.PARQUET_2_0)
+          .build()) {
+        writer.write(groupFactory.newGroup().append("name", "parquet"));
+      }
+      parquetFileBytes = baos.toByteArray();
+    }
+
+    // 3. Read the file metadata to find the offset and size of the first page header
+    InputFile inputFile = getInputFile();
+    try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
+      ParquetMetadata footer = reader.getFooter();
+      assertTrue("No row groups found in test file", footer.getBlocks().size() > 0);
+      BlockMetaData block = footer.getBlocks().get(0);
+      assertTrue("No column chunks found in test file", block.getColumns().size() > 0);
+
+      pageHeaderOffset = block.getColumns().get(0).getFirstDataPageOffset();
+
+      // To get the header length, we must read it from a valid stream
+      try (SeekableInputStream stream = inputFile.newStream()) {
+        stream.seek(pageHeaderOffset);
+        PageHeader header = Util.readPageHeader(stream);
+        long endOfHeaderPos = stream.getPos();
+        pageHeaderLength = (int) (endOfHeaderPos - pageHeaderOffset);
+      }
+    }
+    assertTrue("Could not determine page header length", pageHeaderLength > 0);
+  }
+
+  private static InputFile getInputFile() throws IOException {
+    if (READ_FROM_DISK) {
+      return HadoopInputFile.fromPath(filePath, conf);
+    } else {
+      return new MemoryInputFile(parquetFileBytes);
+    }
+  }
+
+  // Full read of PageHeader from a valid stream should succeed.
+  @Test
+  public void fullReadOfPageHeaderShouldSucceed() {
+    try(SeekableInputStream stream = getInputFile().newStream()) {
+      stream.seek(pageHeaderOffset);
+      Util.readPageHeader(stream);
+    } catch (Exception e) {
+      Assert.fail("Received exception with message " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void intermediatePartialReadWithinPageHeaderShouldNotThrowException() throws IOException {
+    // The absolute position in the stream to inject the fault
+    long absoluteFaultPosition = pageHeaderOffset + FAULT_OFFSET;
+
+    try (SeekableInputStream underlyingStream = getInputFile().newStream()) {
+      // Create a seekable stream and wrap it with our fault-injecting stream
+      PartialReadInputStream faultyStream =
+          new PartialReadInputStream(underlyingStream, absoluteFaultPosition, false);
+      try {
+        faultyStream.seek(pageHeaderOffset);
+        Util.readPageHeader(faultyStream);
+      } catch (Exception e) {
+        Assert.fail("Received exception with message " + e.getMessage());
+      }
+    }
+  }
+
+  @Test
+  public void partialReadWithinPageHeaderShouldThrowException() throws IOException {
+    // The absolute position in the stream to inject the fault
+    long absoluteFaultPosition = pageHeaderOffset + FAULT_OFFSET;
+
+    // Create a seekable stream and wrap it with our fault-injecting stream
+    try (SeekableInputStream underlyingStream = getInputFile().newStream()) {
+      PartialReadInputStream faultyStream = new PartialReadInputStream(underlyingStream, absoluteFaultPosition, true);
+
+      // Assert that attempting to read the header from this faulty stream throws the expected exception
+      assertThrows("A partial read within the PageHeader should cause an IOException.", IOException.class, () -> {
+        faultyStream.seek(pageHeaderOffset);
+        Util.readPageHeader(faultyStream);
+      });
+    }
+  }
+
+  // Helper classes for in-memory file handling
+  private static class MemoryInputFile implements InputFile {
+    private final byte[] data;
+
+    public MemoryInputFile(byte[] data) {
+      this.data = data;
+    }
+
+    @Override
+    public long getLength() {
+      return this.data.length;
+    }
+
+    @Override
+    public SeekableInputStream newStream() {
+      return new SeekableByteArrayInputStream(data);
+    }
+  }
+
+  /**
+   * A simple implementation of OutputFile that writes to a ByteArrayOutputStream.
+   */
+  private static class MemoryOutputFile implements OutputFile {
+    private final ByteArrayOutputStream baos;
+
+    public MemoryOutputFile(ByteArrayOutputStream baos) {
+      this.baos = baos;
+    }
+
+    @Override
+    public PositionOutputStream create(long blockSizeHint) throws IOException {
+      return new PositionOutputStream() {
+        private long position = 0;
+
+        @Override
+        public long getPos() {
+          return position;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+          baos.write(b);
+          position++;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+          baos.write(b, off, len);
+          position += len;
+        }
+      };
+    }
+
+    @Override
+    public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
+      // For this in-memory example, create and createOrOverwrite are the same.
+      baos.reset();
+      return create(blockSizeHint);
+    }
+
+    @Override
+    public boolean supportsBlockSize() {
+      return false;
+    }
+
+    @Override
+    public long defaultBlockSize() {
+      return 0;
+    }
+  }
+
+  private static class SeekableByteArrayInputStream extends DelegatingSeekableInputStream {
+    private final ByteArrayInputStream stream;
+
+    public SeekableByteArrayInputStream(byte[] bytes) {
+      super(new ByteArrayInputStream(bytes));
+      this.stream = (ByteArrayInputStream) getStream();
+    }
+
+    @Override
+    public long getPos() {
+      return stream.available() > 0 ? parquetFileBytes.length - stream.available() : parquetFileBytes.length;
+    }
+
+    @Override
+    public void seek(long newPos) {
+      stream.reset();
+      stream.skip(newPos);
+    }
+  }
+}

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
@@ -101,7 +101,7 @@ public class TestParquetWriter {
   /**
    * A test OutputFile implementation to validate the scenario of an OutputFile is implemented by an API client.
    */
-  private static class TestOutputFile implements OutputFile {
+  public static class TestOutputFile implements OutputFile {
 
     private final OutputFile outputFile;
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/PartialReadInputStream.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/PartialReadInputStream.java
@@ -1,0 +1,91 @@
+package org.apache.parquet.hadoop.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.parquet.io.DelegatingSeekableInputStream;
+
+/**
+ * A SeekableInputStream wrapper that simulates a partial read at a specific position.
+ * It reads normally until a designated fault position is reached. At that point,
+ * return -1 to simulate EOF or return a single byte to signify a partial read.
+ */
+public class PartialReadInputStream extends DelegatingSeekableInputStream {
+
+  private final long faultTriggerPosition;
+  private boolean faultInjected = false;
+  private boolean shouldFailWithEOF = true;
+
+  /**
+   * Constructs a PartialReadInputStream.
+   *
+   * @param stream The underlying InputStream to wrap.
+   * @param faultTriggerPosition The absolute position in the stream at which to inject a partial read.
+   */
+  public PartialReadInputStream(InputStream stream, long faultTriggerPosition, boolean shouldFailWithEOF) {
+    super(stream);
+    this.faultTriggerPosition = faultTriggerPosition;
+    this.shouldFailWithEOF = shouldFailWithEOF;
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    if (shouldFailWithEOF) {
+      return readInternalEOF(b, off, len);
+    }
+    return readInternalPartial(b, off, len);
+  }
+
+  private int readInternalPartial(byte[] b, int off, int len) throws IOException {
+    long currentPos = getPos();
+
+    if (!faultInjected && currentPos >= faultTriggerPosition) {
+      // Inject the fault: perform a single-byte read to simulate a partial read.
+      faultInjected = true;
+      int byteRead = super.read();
+      if (byteRead == -1) {
+        return -1;
+      }
+      b[off] = (byte) byteRead;
+      return 1; // Return 1 to signify a partial read.
+    }
+    return super.read(b, off, len);
+  }
+
+  private int readInternalEOF(byte[] b, int off, int len) throws IOException {
+    long currentPos = getPos();
+
+    // If the read position is at or beyond the fault trigger,
+    // simulate a premature end-of-file.
+    if (currentPos >= faultTriggerPosition) {
+      faultInjected = true;
+      return -1; // Simulate EOF
+    }
+
+    // If the current read request would cross the fault boundary,
+    // truncate the read to stop exactly at the fault position.
+    if ((currentPos + len) > faultTriggerPosition) {
+      int truncatedLen = (int) (faultTriggerPosition - currentPos);
+      return super.read(b, off, truncatedLen);
+    }
+
+    // Otherwise, perform a normal read.
+    return super.read(b, off, len);
+  }
+
+  // The following methods must be implemented as DelegatingSeekableInputStream is abstract.
+  // They should delegate to the underlying stream if it is seekable, or throw if not.
+  // For this test's purpose (using ByteArrayInputStream), these are sufficient.
+
+  @Override
+  public long getPos() throws IOException {
+    // This assumes the underlying stream is a ByteArrayInputStream or similar
+    // where available() can be used to infer position. A more robust implementation
+    // would require a truly seekable stream.
+    return ((DelegatingSeekableInputStream) getStream()).getPos();
+  }
+
+  @Override
+  public void seek(long newPos) throws IOException {
+    ((DelegatingSeekableInputStream) getStream()).seek(newPos);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <spotless.version>2.30.0</spotless.version>
     <shade.prefix>shaded.parquet</shade.prefix>
     <!-- Guarantees no newer classes/methods/constants are used by parquet. -->
-    <hadoop.version>3.3.0</hadoop.version>
+    <hadoop.version>3.3.6</hadoop.version>
     <parquet.format.version>2.11.0</parquet.format.version>
     <previous.version>1.15.1</previous.version>
     <thrift.executable>thrift</thrift.executable>


### PR DESCRIPTION
How to use these changes - 

- Clone parquet-java library
- Apply patch from this Pull request(or cherry-pick commit 28eaf66d34d841b2222a2cc9a986626305d50fc0 and 92bd171f123878e7e329fcbcb2be229e2d17b07d from this repo)
- Copy parquet file to /dev/shm/ or use GCS URI(starts with gs://) and update the correct path in [TestPageHeaderPartialRead.java](https://github.com/animesh-g/parquet-java/compare/master...animesh-g:parquet-java:partial-read-sim?expand=1#diff-2c994ba6f2607f7888b11989fd5c5aa2b2391669fedbaf5712ea7fef597fb4d7) in PARQUET_FILE_PATH variable.
- Make sure READ_FROM_DISK is set to `true`. Use `false` value if you want to create a in memory parquet file
-  Change FAULT_OFFSET value (optional).
- Run this test using following command 
`./mvnw test -pl parquet-hadoop -Drat.skip=true -Dtest=TestPageHeaderPartialRead`
- Observe the result. All 3 unit tests should pass.

Note: SInce /dev/shm is in-memory file system, make sure the parquet file created be able to fit into the RAM. Not applicable to gcs path parquet files.